### PR TITLE
Update fzf to 0.61.1

### DIFF
--- a/fzf/bgn+keys.ices.zsh
+++ b/fzf/bgn+keys.ices.zsh
@@ -9,10 +9,10 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='go;make;cp;bgn'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
-    atclone'PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install &&
+    atclone'PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install &&
       mkdir -p $ZPFX/{bin,man/man1} &&
       cp shell/completion.zsh _fzf_completion &&
       cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1' \

--- a/fzf/bgn-binary+keys.ices.zsh
+++ b/fzf/bgn-binary+keys.ices.zsh
@@ -9,7 +9,7 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='cp;bgn;dl'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
     atclone'mkdir -p $ZPFX/{bin,man/man1}' \

--- a/fzf/bgn-binary.ices.zsh
+++ b/fzf/bgn-binary.ices.zsh
@@ -9,7 +9,7 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='cp;bgn'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
     atclone'mkdir -p $ZPFX/{bin,man/man1}' \

--- a/fzf/bgn.ices.zsh
+++ b/fzf/bgn.ices.zsh
@@ -9,10 +9,10 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='go;make;cp;bgn'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
-    atclone'PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install &&
+    atclone'PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install &&
       mkdir -p $ZPFX/{bin,man/man1};
       cp shell/completion.zsh _fzf_completion;
       cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1' \

--- a/fzf/binary+keys.ices.zsh
+++ b/fzf/binary+keys.ices.zsh
@@ -9,7 +9,7 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='cp;dl'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
     as'command' \

--- a/fzf/binary.ices.zsh
+++ b/fzf/binary.ices.zsh
@@ -9,7 +9,7 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='cp'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
     as'command' \

--- a/fzf/default+keys.ices.zsh
+++ b/fzf/default+keys.ices.zsh
@@ -9,11 +9,11 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='go;make;cp'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
     as'command' \
-    atclone'PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install &&
+    atclone'PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install &&
       mkdir -p $ZPFX/{bin,man/man1} &&
       cp shell/completion.zsh _fzf_completion &&
       cp -vf bin/fzf(|-tmux) $ZPFX/bin &&

--- a/fzf/default.ices.zsh
+++ b/fzf/default.ices.zsh
@@ -9,11 +9,11 @@ NAME='zsh-fzf'
 PARAM_DEFAULT=''
 REQUIREMENTS='go;make;cp'
 URL='https://github.com/junegunn/fzf'
-VERSION='0.28.0'
+VERSION='0.61.1'
 
 zinit \
     as'command' \
-    atclone'PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install &&
+    atclone'PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install &&
       mkdir -p $ZPFX/{bin,man/man1} &&
       cp shell/completion.zsh _fzf_completion &&
       cp -vf bin/fzf(|-tmux) $ZPFX/bin &&

--- a/fzf/package.json
+++ b/fzf/package.json
@@ -1,23 +1,23 @@
 {
-    "_from": "fzf@^0.28.0",
-    "_id": "zsh-fzf@0.28.0",
+    "_from": "fzf@^0.61.1",
+    "_id": "zsh-fzf@0.61.1",
     "_inBundle": false,
     "_location": "/zsh-fzf",
     "_phantomChildren": {},
     "_requested": {
         "type": "range",
         "registry": true,
-        "raw": "fzf@^0.28.0",
+        "raw": "fzf@^0.61.1",
         "name": "fzf",
         "escapedName": "fzf",
-        "rawSpec": "^0.28.0",
+        "rawSpec": "^0.61.1",
         "saveSpec": null,
-        "fetchSpec": "^0.28.0"
+        "fetchSpec": "^0.61.1"
     },
     "_requiredBy": [],
-    "_resolved": "https://github.com/junegunn/fzf/archive/0.28.0.tar.gz",
+    "_resolved": "https://github.com/junegunn/fzf/archive/0.61.1.tar.gz",
     "_shasum": "05bbfa4dd84b72e55afc3fe56c0fc185d6dd1fa1c4eef56a1559b68341f3d029",
-    "_spec": "fzf@^0.28.0",
+    "_spec": "fzf@^0.61.1",
     "_where": "/root/github2/pkg-fzf",
     "author": "Junegunn Choi",
     "bugs": {
@@ -43,12 +43,12 @@
     "scripts": {
         "test": "make test"
     },
-    "version": "0.28.0",
+    "version": "0.61.1",
     "zsh-data": {
         "plugin-info": {
             "user": "junegunn",
             "plugin": "fzf",
-            "version": "0.28.0"
+            "version": "0.61.1"
         },
         "zinit-ices": {
             "default": {
@@ -57,7 +57,7 @@
                 "lucid": "",
                 "as": "command",
                 "pick": "$ZPFX/bin/fzf(|-tmux)",
-                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1} && cp shell/completion.zsh _fzf_completion && cp -vf bin/fzf(|-tmux) $ZPFX/bin && cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
+                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1} && cp shell/completion.zsh _fzf_completion && cp -vf bin/fzf(|-tmux) $ZPFX/bin && cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
                 "atpull": "%atclone",
                 "nocompile": ""
             },
@@ -67,7 +67,7 @@
                 "lucid": "",
                 "as": "command",
                 "pick": "$ZPFX/bin/fzf(|-tmux)",
-                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1} && cp shell/completion.zsh _fzf_completion && cp -vf bin/fzf(|-tmux) $ZPFX/bin && cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
+                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1} && cp shell/completion.zsh _fzf_completion && cp -vf bin/fzf(|-tmux) $ZPFX/bin && cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
                 "atpull": "%atclone",
                 "src": "shell/key-bindings.zsh",
                 "nocompile": ""
@@ -77,7 +77,7 @@
                 "depth": 1,
                 "lucid": "",
                 "pick": "/dev/null",
-                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1}; cp shell/completion.zsh _fzf_completion; cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
+                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1}; cp shell/completion.zsh _fzf_completion; cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
                 "atpull": "%atclone",
                 "sbin": "bin/fzf*",
                 "nocompile": ""
@@ -87,7 +87,7 @@
                 "depth": 1,
                 "lucid": "",
                 "pick": "/dev/null",
-                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.28.0 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1} && cp shell/completion.zsh _fzf_completion && cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
+                "atclone": "PREFIX=$ZPFX FZF_VERSION=0.61.1 FZF_REVISION=zinit-pack make install && mkdir -p $ZPFX/{bin,man/man1} && cp shell/completion.zsh _fzf_completion && cp -vf man/man1/fzf(|-tmux).1 $ZPFX/man/man1",
                 "atpull": "%atclone",
                 "make": "install",
                 "sbin": "bin/fzf*",


### PR DESCRIPTION
## Description
A simple version update so we can enjoy the `pack` syntax **and** use `source <(fzf --zsh)`, as version 0.28.0 does not have it.

## How Has This Been Tested?
No test at all... I just copied the scripts and installed it locally with the updated version (and it worked).

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
