### PR TITLE
Added "v" prefix to URL

### DIFF
--- a/fzf/package.json
+++ b/fzf/package.json
@@ -15,7 +15,7 @@
         "fetchSpec": "^0.61.1"
     },
     "_requiredBy": [],
-    "_resolved": "https://github.com/junegunn/fzf/archive/0.61.1.tar.gz",
+    "_resolved": "https://github.com/junegunn/fzf/archive/v0.61.1.tar.gz",
     "_shasum": "05bbfa4dd84b72e55afc3fe56c0fc185d6dd1fa1c4eef56a1559b68341f3d029",
     "_spec": "fzf@^0.61.1",
     "_where": "/root/github2/pkg-fzf",


### PR DESCRIPTION
## Description
Since `0.53.0` `fzf` adds a `v` prefix to the tags, so the correct reference to the tarball is `v0.61.1` at the time of writing.

## Related Issue(s)
https://github.com/zdharma-continuum/zinit-packages/pull/16 

## Motivation and Context <!--- What problem does it solve? -->


## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
